### PR TITLE
Removing permission and command usage from plugin.yml

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -8,5 +8,3 @@ commands:
     aliases:
       - redworldspawn
       - worldspawn
-    permission: rwm.redworldspawn.use
-    usage: /wspawn

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -8,3 +8,4 @@ commands:
     aliases:
       - redworldspawn
       - worldspawn
+    usage: /wspawn


### PR DESCRIPTION
- use no permission message of the config.yml and not of bukkit / spigot
- remove unused usage info of main command (not necessary)